### PR TITLE
Fixing bug with arguemnt for -v key

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ mtproxy_connections: 0
 mtproxy_log: ""
 mtproxy_port: 8888
 mtproxy_user: "mtproxy"
-mtproxy_verbosity: 0
+mtproxy_verbosity: False
 mtproxy_aes_pwd: "{{ mtproxy_config_path }}/proxy-secret"
 mtproxy_config: "{{ mtproxy_config_path }}/proxy-multi.conf"
 mtproxy_msg_buffers_size: 268435456

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ mtproxy_connections: 0
 mtproxy_log: ""
 mtproxy_port: 8888
 mtproxy_user: "mtproxy"
-mtproxy_verbosity: 0
+mtproxy_verbosity: False
 mtproxy_aes_pwd: "{{ mtproxy_config_path }}/proxy-secret"
 mtproxy_config: "{{ mtproxy_config_path }}/proxy-multi.conf"
 mtproxy_msg_buffers_size: 268435456

--- a/templates/mtproxy.service.j2
+++ b/templates/mtproxy.service.j2
@@ -47,7 +47,7 @@ ExecStart=/usr/bin/mtproto-proxy -u {{ mtproxy_user }} \
   -l {{ mtproxy_log }} \
 {% endif %}
 {% if mtproxy_verbosity != 0 %}
-  -v {{ mtproxy_verbosity }} \
+  -v \
 {% endif %}
 {% if mtproxy_msg_buffers_size != 268435456 %}
   --msg-buffers-size {{ mtproxy_msg_buffers_size }} \

--- a/templates/mtproxy.service.j2
+++ b/templates/mtproxy.service.j2
@@ -46,7 +46,7 @@ ExecStart=/usr/bin/mtproto-proxy -u {{ mtproxy_user }} \
 {% if mtproxy_log | length > 0 %}
   -l {{ mtproxy_log }} \
 {% endif %}
-{% if mtproxy_verbosity != 0 %}
+{% if mtproxy_verbosity %}
   -v \
 {% endif %}
 {% if mtproxy_msg_buffers_size != 268435456 %}


### PR DESCRIPTION
According to mtproxy help, "-v" key doesn't require any value. If you pass any value for this key mtproto servr will crash.